### PR TITLE
Log message should show the grammar file

### DIFF
--- a/tasks/peg.js
+++ b/tasks/peg.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
   // creation: http://gruntjs.com/creating-tasks
 
   grunt.registerMultiTask('peg', 'Generates parsers from PEG grammars.', function() {
-    grunt.log.write(grunt.template.process('Generating parser from <%= grammar %>', this.data));
+    grunt.log.write(grunt.template.process('Generating parser from <%= grammar %>', this));
     var grammar = grunt.file.read(this.data.grammar);
     grunt.file.write(this.data.outputFile, parserSource(grammar, this.data.exportVar));
   });


### PR DESCRIPTION
I think either grunt.template.process or the underlying lodash.template function changed their signature to take an options object that can contain a data object rather than a data object directly.
