### PR TITLE
JSHint doesn't like the ES5 option any more

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }


### PR DESCRIPTION
JSHint aborts with the error "ES5 option is now set per default" when the es5 option is set, it's now the default so it's safe to remove.
