### PR TITLE
add a license header to source files

### DIFF
--- a/test/peg_test.js
+++ b/test/peg_test.js
@@ -1,3 +1,11 @@
+/*
+ * grunt-peg
+ * https://github.com/dvberkel/grunt-peg
+ *
+ * Copyright (c) 2013 Daan van Berkel
+ * Licensed under the MIT license.
+ */
+
 'use strict';
 
 var grunt = require('grunt');


### PR DESCRIPTION
As requested in issue #12 all source files are required to have a license header. This merge adds a license header to the only source file that did not have a license header as of yet. I.e. `test/peg_test.js`
